### PR TITLE
[TECI-517] Configure Topology Spread Constraints in our existing helm…

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -115,3 +115,13 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.topologySpreadConstraints.enable }}
+      topologySpreadConstraints: 
+        - labelSelector:
+            matchLabels:
+              app: {{ .Release.Name }}
+              type: {{ .Chart.Name }}
+          maxSkew: {{ .Values.topologySpreadConstraints.maxSkew  }}
+          topologyKey: {{ .Values.topologySpreadConstraints.topologyKey  | quote  }}
+          whenUnsatisfiable: {{ .Values.topologySpreadConstraints.whenUnsatisfiable }}
+    {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -61,3 +61,12 @@ metadata:
       env: ""
       service: ""
       version: ""
+
+topologySpreadConstraints: 
+  enable: false
+  # -- Enable pod [Topology Spread Constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/).
+  maxSkew: 1
+  # -- The key of node labels.
+  # See https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/
+  topologyKey: "kubernetes.io/hostname"
+  whenUnsatisfiable: DoNotSchedule

--- a/values.yaml
+++ b/values.yaml
@@ -69,4 +69,4 @@ topologySpreadConstraints:
   # -- The key of node labels.
   # See https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/
   topologyKey: "kubernetes.io/hostname"
-  whenUnsatisfiable: DoNotSchedule
+  whenUnsatisfiable: ScheduleAnyway


### PR DESCRIPTION
- Pods are equally deployed between all the nodes 
- The solution is tested on Sandbox

Jira:
https://jira.tx.group/browse/TECI-517

Right now the Topology Spread Constraints is disabled if we need to activate it, we need to add these lines in the value.yaml of the helm chart:


> topologySpreadConstraints: 
>   enable: true

