### PR TITLE
Add startup probe to prevent killing containers too early

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -92,6 +92,7 @@ spec:
               port: http
             initialDelaySeconds: {{ .Values.probe.livenessInitialDelaySeconds }}
             periodSeconds: {{ .Values.probe.livenessPeriodSeconds }}
+            timeoutSeconds: {{ .Values.probe.livenessTimeoutSeconds }}
           {{- end }}
           {{- if .Values.probe.readiness }}
           readinessProbe:
@@ -100,6 +101,19 @@ spec:
               port: http
             initialDelaySeconds: {{ .Values.probe.readinessInitialDelaySeconds }}
             periodSeconds: {{ .Values.probe.readinessPeriodSeconds }}
+            timeoutSeconds: {{ .Values.probe.readinessTimeoutSeconds }}
+          {{- end }}
+          # Let's add startup probe only if there is already a liveness defined without requiring new values on application side
+          {{- if .Values.probe.liveness }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.probe.liveness | quote }}
+              port: http
+            # This means that by default, any application who doesn't respond after 6*20 seconds (2 minutes) gets killed and restarted
+            # Can be dangerous if we have slow-starting apps. Can we assume that in 2 minutes all the apps are ready to serve content? Currently anyway 
+            failureThreshold: 20
+            periodSeconds: 6
+            timeoutSeconds: 2
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/values.yaml
+++ b/values.yaml
@@ -22,9 +22,11 @@ probe:
   liveness: /
   livenessInitialDelaySeconds: 0
   livenessPeriodSeconds: 10
+  livenessTimeoutSeconds: 2
   readiness: /
   readinessInitialDelaySeconds: 0
   readinessPeriodSeconds: 10
+  readinessTimeoutSeconds: 2
 
 service:
   enabled: true


### PR DESCRIPTION
Keep in mind that this will be applied to all the apps using the v2.3.0 of this chart.

Why do we need a startupProbe at all? I noticed some containers restarts in Disco and 20Min. By checking the events log I could see that they were happening at the start of the Pods because `liveness` checks were failing. The goal of liveness is not to restart the Pod before it even reached a good working state, and restarting the containers slows down even more the ability to scale in time. So I'm adding a bit more delay (the startupProbe) before the liveness check is scheduled. By doing so

Anyway I checked and in disco + 20min we, **at most**, define a liveness that lasts 40 seconds in total. If the container doesn't answer after 40 secs it's being restarted. 

So I'm setting a higher default, which shouldn't be an issue because if a container is fast, it will be fast anyway! This doesn't slow it down.

Another change is to increase the probe response timeout from the default 1 second to 2 seconds. By doing so we allow slower containers a bit more time to consider a probe timed out.

**Tested**: with the flaky deployments (there were 1-3 restarts at deployments of personalization and editor) and the number of restarts went to 0. It is working.