### PR TITLE
Reduce readiness probe sensitivity in order to be more reactive, by default

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -102,6 +102,7 @@ spec:
             initialDelaySeconds: {{ .Values.probe.readinessInitialDelaySeconds }}
             periodSeconds: {{ .Values.probe.readinessPeriodSeconds }}
             timeoutSeconds: {{ .Values.probe.readinessTimeoutSeconds }}
+            failureThreshold: {{ .Value.probe.readinessFailureThreshold }}
           {{- end }}
           # Let's add startup probe only if there is already a liveness defined without requiring new values on application side
           {{- if .Values.probe.liveness }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -102,7 +102,7 @@ spec:
             initialDelaySeconds: {{ .Values.probe.readinessInitialDelaySeconds }}
             periodSeconds: {{ .Values.probe.readinessPeriodSeconds }}
             timeoutSeconds: {{ .Values.probe.readinessTimeoutSeconds }}
-            failureThreshold: {{ .Value.probe.readinessFailureThreshold }}
+            failureThreshold: {{ .Values.probe.readinessFailureThreshold }}
           {{- end }}
           # Let's add startup probe only if there is already a liveness defined without requiring new values on application side
           {{- if .Values.probe.liveness }}

--- a/values.yaml
+++ b/values.yaml
@@ -25,7 +25,8 @@ probe:
   livenessTimeoutSeconds: 2
   readiness: /
   readinessInitialDelaySeconds: 0
-  readinessPeriodSeconds: 10
+  readinessPeriodSeconds: 6
+  readinessFailureThreshold: 2
   readinessTimeoutSeconds: 2
 
 service:


### PR DESCRIPTION
[FUM-2184](https://jira.tx.group/browse/FUM-2184) 

In the last comments of the ticket I explained my findings. If you don't agree, let's have a chat and discuss that.

Keep in mind that not answering an internal healthcheck in more than 2 seconds never happens, only in critical situations. And if it does, it really means something is off.