### PR TITLE
Remove memory auto-scaling by default

### DIFF
--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -8,13 +8,15 @@ spec:
   maxReplicas: {{ .Values.scale.maxReplicas }}
   metrics:
     - resource:
-        name: memory
-        targetAverageUtilization: {{ .Values.scale.memoryThresholdPercentage }}
-      type: Resource
-    - resource:
         name: cpu
         targetAverageUtilization: {{ .Values.scale.cpuThresholdPercentage }}
       type: Resource
+    {{- if .Values.scale.memoryThresholdPercentage }}
+    - resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.scale.memoryThresholdPercentage }}
+      type: Resource
+    {{- end }}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/values.yaml
+++ b/values.yaml
@@ -4,7 +4,6 @@ scale:
   maxReplicas: 10
   minAvailable: 50%
   cpuThresholdPercentage: 60
-  memoryThresholdPercentage: 60
 
 port: 80
 # ["bundle", "exec", "rake", "db:create", "db:migrate"]


### PR DESCRIPTION
By default we should not auto-scale by looking at memory metrics.

Only few applications should autoscale because of memory load and they should explicitly set this.