### PR TITLE
feat: set rollingupdate strategy with 0% maxUnavailable + multiple TopologySpreadConstraints

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -142,3 +142,8 @@ spec:
           topologyKey: {{ .Values.topologySpreadConstraints.topologyKey | quote }}
           whenUnsatisfiable: {{ .Values.topologySpreadConstraints.whenUnsatisfiable }}
     {{- end }}
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 0%
+          maxSurge: 25%

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -120,7 +120,6 @@ spec:
             # This means that by default, any application who doesn't respond after 3*40 seconds (2 minutes) gets killed and restarted
             # Can be dangerous if we have slow-starting apps. Can we assume that in 2 minutes all the apps are ready to serve content? Currently anyway 
             failureThreshold: 40
-            successThreshold: 2  # Require 2 successful calls to the startup probe before considering it started successfully.
             periodSeconds: 3
             timeoutSeconds: 2
           {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -133,17 +133,19 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- if .Values.topologySpreadConstraints.enabled }}
-      topologySpreadConstraints: 
-        - labelSelector:
+      topologySpreadConstraints:
+        {{- range .Values.topologySpreadConstraints.topologyKeys }}
+        - topologyKey: {{ . | quote }}
+          labelSelector:
             matchLabels:
-              app: {{ .Release.Name }}
-              type: {{ .Chart.Name }}
-          maxSkew: {{ .Values.topologySpreadConstraints.maxSkew }}
-          topologyKey: {{ .Values.topologySpreadConstraints.topologyKey | quote }}
-          whenUnsatisfiable: {{ .Values.topologySpreadConstraints.whenUnsatisfiable }}
+              app: {{ $.Release.Name }}
+              type: {{ $.Chart.Name }}
+          maxSkew: {{ $.Values.topologySpreadConstraints.maxSkew }}
+          whenUnsatisfiable: {{ $.Values.topologySpreadConstraints.whenUnsatisfiable }}
+        {{- end }}
     {{- end }}
       strategy:
         type: RollingUpdate
         rollingUpdate:
-          maxUnavailable: 0%
-          maxSurge: 25%
+          maxUnavailable: {{ .Values.update.maxUnavailable }}
+          maxSurge: {{ .Values.update.maxSurge }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -38,6 +38,11 @@ spec:
         {{- if .Values.metadata.labels.datadog.version }}
         tags.datadoghq.com/version: {{ .Values.metadata.labels.datadog.version }}
         {{- end }}
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: {{ .Values.update.maxUnavailable }}
+        maxSurge: {{ .Values.update.maxSurge }}
     spec:
       {{- if .Values.aws_iam_role_arn }}
       serviceAccountName: {{ .Release.Name }}
@@ -144,8 +149,3 @@ spec:
           whenUnsatisfiable: {{ $.Values.topologySpreadConstraints.whenUnsatisfiable }}
         {{- end }}
     {{- end }}
-      strategy:
-        type: RollingUpdate
-        rollingUpdate:
-          maxUnavailable: {{ .Values.update.maxUnavailable }}
-          maxSurge: {{ .Values.update.maxSurge }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -115,12 +115,13 @@ spec:
           {{- if .Values.probe.liveness }}
           startupProbe:
             httpGet:
-              path: {{ .Values.probe.liveness | quote }}
+              path: {{ coalesce .Values.probe.startup .Values.probe.liveness | quote }}
               port: http
-            # This means that by default, any application who doesn't respond after 6*20 seconds (2 minutes) gets killed and restarted
+            # This means that by default, any application who doesn't respond after 3*40 seconds (2 minutes) gets killed and restarted
             # Can be dangerous if we have slow-starting apps. Can we assume that in 2 minutes all the apps are ready to serve content? Currently anyway 
-            failureThreshold: 20
-            periodSeconds: 6
+            failureThreshold: 40
+            successThreshold: 2  # Require 2 successful calls to the startup probe before considering it started successfully.
+            periodSeconds: 3
             timeoutSeconds: 2
           {{- end }}
           resources:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -24,6 +24,11 @@ spec:
     matchLabels:
       type: {{ .Chart.Name }}
       app: {{ .Release.Name }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ .Values.update.maxUnavailable }}
+      maxSurge: {{ .Values.update.maxSurge }}
   template:
     metadata:
       labels:
@@ -38,11 +43,6 @@ spec:
         {{- if .Values.metadata.labels.datadog.version }}
         tags.datadoghq.com/version: {{ .Values.metadata.labels.datadog.version }}
         {{- end }}
-    strategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxUnavailable: {{ .Values.update.maxUnavailable }}
-        maxSurge: {{ .Values.update.maxSurge }}
     spec:
       {{- if .Values.aws_iam_role_arn }}
       serviceAccountName: {{ .Release.Name }}

--- a/values.yaml
+++ b/values.yaml
@@ -5,7 +5,8 @@ scale:
   maxReplicas: 10
   minAvailable: 50%
   cpuThresholdPercentage: 100
-  memoryThresholdPercentage: -1  # -1 means "unset". Use positive integer to enable it.
+  # -1 means "unset". Use positive integer to enable it.
+  memoryThresholdPercentage: -1
 
 port: 80
 # ["bundle", "exec", "rake", "db:create", "db:migrate"]
@@ -76,5 +77,12 @@ topologySpreadConstraints:
   maxSkew: 1
   # -- The key of node labels.
   # See https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/
-  topologyKey: "topology.kubernetes.io/zone"
+  # All the labels will be considered to try to find the best match
+  topologyKeys:
+    - topology.kubernetes.io/zone
+    - kubernetes.io/hostname
   whenUnsatisfiable: ScheduleAnyway
+
+update:
+  maxUnavailable: 0%
+  maxSurge: 25%

--- a/values.yaml
+++ b/values.yaml
@@ -27,9 +27,10 @@ probe:
   livenessTimeoutSeconds: 2
   readiness: /
   readinessInitialDelaySeconds: 0
-  readinessPeriodSeconds: 6
+  readinessPeriodSeconds: 5
   readinessFailureThreshold: 2
   readinessTimeoutSeconds: 2
+  startup:
 
 service:
   annotations:


### PR DESCRIPTION
## Changes
### Update rollingUpdate strategy
If `strategy` is not defined, by default Kubernetes Deployments use:
```yaml
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 25%
      maxSurge: 25%
```

Let's take an easy example to explain what happens when a new deployment occurs:
1. service `A` has 100 replicas
2. service `A` gets a new deployment
3. 25 replicas (`maxUnavailable`) will be sent `SIGTERM` and put into `Terminating` state
4. 25 replicas (`maxSurge`) will be created
5. Once terminated and once created the process can go on and during the entire process the number of Ready replicas will vary between 75% and 125% of the initial replicaCount.

It's obvious that if your 100 replicas are under stress, it's not recommended to bring them down to 75 as they will be under stronger stress (75 sharing the burden of 100).

As a consequence we therefore suggest to not allow any "downscale" **by default**, but rather upscaling only and therefore the app-helm-chart will have the following strategy:
```yaml
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 0%
      maxSurge: 25%
```
By doing so, the number of Ready replicas will fluctuate between 100% and 125% during deployment. This will, as a side effect, slow down deployment time but safeguarding app performance.

### Add multiple topologySpreadConstraints - [FUM-2112](https://jira.tx.group/browse/FUM-2112)

Another addition of the PR is the possibility of having multiple topology keys to be used parallely. 

By default, using the `topologySpreadConstraints.topologyKeys` value, we set to spread across:
1. Zones (e.g. eu-central-1a, eu-central-1b, eu-central-1c)
2. Nodes (e.g. ip-1-2-3-4....., ip-2-4-6-8....., etc...)

This is a breaking change (from `topologyKey` to `topologyKeys`), but nobody is overriding this key so we can consider it safe