### PR TITLE
fix: explicitly cast inputs to integers for comparison

### DIFF
--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -8,13 +8,11 @@ spec:
   minReplicas: {{ .Values.scale.minReplicas }}
   maxReplicas: {{ .Values.scale.maxReplicas }}
   metrics:
-    {{- if kindIs "int64" .Values.scale.memoryThresholdPercentage }}
-    {{- if ne .Values.scale.memoryThresholdPercentage -1 }}
+    {{- if ne (int .Values.scale.memoryThresholdPercentage) -1 }}
     - resource:
         name: memory
         targetAverageUtilization: {{ .Values.scale.memoryThresholdPercentage }}
       type: Resource
-    {{- end }}
     {{- end }}
     - resource:
         name: cpu

--- a/templates/pod_disruption_budget.yaml
+++ b/templates/pod_disruption_budget.yaml
@@ -1,7 +1,6 @@
-{{- if kindIs "int64" .Values.scale.minReplicas }}
 # by setting minReplica = 1 the PDB won't be deployed.
 # if you want HA then minReplica must be > 1.
-{{- if gt .Values.scale.minReplicas 1 }}
+{{- if gt (int .Values.scale.minReplicas) 1 }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -12,5 +11,4 @@ spec:
     matchLabels:
       type: {{ .Chart.Name }}
       app: {{ .Release.Name }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
This is fixing a bug where sometimes the `minReplicas` argument is casted as float64 and therefore not passing the `kindIs` condition.

PDBs were affected and therefore not deployed. This fixes it.