### PR TITLE
feat: allow setting annotations on app-helm-chart

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
       maxSurge: {{ .Values.update.maxSurge }}
   template:
     metadata:
+      annotations:
+        {{- toYaml .Values.metadata.annotations | nindent 8 }}
       labels:
         type: {{ .Chart.Name }}
         app: {{ .Release.Name }}

--- a/values.yaml
+++ b/values.yaml
@@ -68,6 +68,7 @@ tolerations: []
 affinity: {}
 
 metadata:
+  annotations: {}
   labels:
     datadog:
       env: ""


### PR DESCRIPTION
In order to enable Prometheus auto-discovery of services, we have to enable the possibility to set annotations at the Pod-level so that we can set:
```
metadata:
  annotations:
    prometheus.io/scrape: "true"
    prometheus.io/port: "9877"
```

After this I will bump app-helm-chart version to `3.4.0`