### PR TITLE
remove default topology contraint and use the cluster default

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -124,7 +124,7 @@ spec:
                 {{ .Values.probe.startupHttpHeaders | toYaml | nindent 16 }}
               {{- end }}
             # This means that by default, any application who doesn't respond after 3*40 seconds (2 minutes) gets killed and restarted
-            # Can be dangerous if we have slow-starting apps. Can we assume that in 2 minutes all the apps are ready to serve content? Currently anyway 
+            # Can be dangerous if we have slow-starting apps. Can we assume that in 2 minutes all the apps are ready to serve content? Currently anyway
             failureThreshold: 40
             periodSeconds: 3
             timeoutSeconds: {{ .Values.probe.startupTimeoutSeconds }}
@@ -143,15 +143,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if .Values.topologySpreadConstraints.enabled }}
-      topologySpreadConstraints:
-        {{- range .Values.topologySpreadConstraints.topologyKeys }}
-        - topologyKey: {{ . | quote }}
-          labelSelector:
-            matchLabels:
-              app: {{ $.Release.Name }}
-              type: {{ $.Chart.Name }}
-          maxSkew: {{ $.Values.topologySpreadConstraints.maxSkew }}
-          whenUnsatisfiable: {{ $.Values.topologySpreadConstraints.whenUnsatisfiable }}
-        {{- end }}
+    {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml .Values.topologySpreadConstraints | nindent 8 }}
     {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -76,17 +76,20 @@ metadata:
       version: ""
 
 topologySpreadConstraints:
-  enabled: true
-  # -- Enable pod [Topology Spread Constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/).
-  maxSkew: 1
-  # -- The key of node labels.
-  # See https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/
-  # All the labels will be considered to try to find the best match
-  topologyKeys:
-    - topology.kubernetes.io/zone
-    - kubernetes.io/hostname
-  whenUnsatisfiable: ScheduleAnyway
-
+  # -- Enable pod [Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/).
+  # If no constraints are defined, the cluster default is used.
+  # - topologyKey: topology.kubernetes.io/zone
+  #   maxSkew: 5
+  #   whenUnsatisfiable: ScheduleAnyway
+  # - topologyKey: kubernetes.io/hostname
+  #   maxSkew: 3
+  #   whenUnsatisfiable: ScheduleAnyway
+  - topologyKey: topology.kubernetes.io/zone
+    maxSkew: 1
+    whenUnsatisfiable: ScheduleAnyway
+  - topologyKey: kubernetes.io/hostname
+    maxSkew: 1
+    whenUnsatisfiable: ScheduleAnyway
 update:
   maxUnavailable: 0%
   maxSurge: 25%


### PR DESCRIPTION
I want to be able to set individual constraints and its easier to pass the constraints as plain yaml

```
topologySpreadConstraints:
  - maxSkew: 3
    topologyKey: "kubernetes.io/hostname"
    whenUnsatisfiable: ScheduleAnyway
  - maxSkew: 5
    topologyKey: "topology.kubernetes.io/zone"
    whenUnsatisfiable: ScheduleAnyway
 ```