### PR TITLE
feat!: rename annotations to podAnnotations and introduce Deployment and HPA annotations customization

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -2,6 +2,9 @@ name: Lint and Test Charts
 
 on: push
 
+env:
+  HELM_VERSION: v3.8.1
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest
@@ -14,7 +17,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.8.1
+          version: ${{ env.HELM_VERSION }}
 
       - uses: actions/setup-python@v5
         with:
@@ -25,3 +28,25 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: ct lint --chart-dirs . --charts .
+
+  template-test:
+    needs: [lint-test]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        file:
+          - name: ""
+          - name: ci/values-minimal.yaml
+          - name: ci/values-complete.yaml
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Run chart-testing (template) on different YAML files
+        run: helm template --dry-run --generate-name . -f ${{ matrix.file.name }}

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: true
       matrix:
         file:
-          - name: ""
+          - name: ci/values-empty.yaml
           - name: ci/values-minimal.yaml
           - name: ci/values-complete.yaml
     steps:
@@ -49,4 +49,4 @@ jobs:
           version: ${{ env.HELM_VERSION }}
 
       - name: Run chart-testing (template) on different YAML files
-        run: helm template --dry-run --generate-name . -f ${{ matrix.file.name }}
+        run: helm template --dry-run --generate-name . -f "${{ matrix.file.name }}"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # app-helm-chart
+
 Contains the generic helm chart for an application. It is used by Prometheus & Disco project
 
 ## Usage
@@ -32,3 +33,12 @@ For highly-available deployments, the chart allows a minimum availability of 50%
 You can configure it by overriding the `scale.minAvailable` parameter. (e.g. `90%`)
 
 **Note:** PDBs are **only** deployed together with deployments that have more than one replica.
+
+## Tests
+
+There are multiple complementary ways to test the chart before relesing it. We have defined workflow that uses the `chart-testing` (`ct`) library to:
+
+1. Lint the chart
+1. Run template with different `values.yaml` files (`ci` folder)
+
+Further development points could include running a `kind` K8s cluster and deploying the charts to that cluster, adding some more specific K8s linting, ...

--- a/ci/values-complete.yaml
+++ b/ci/values-complete.yaml
@@ -6,9 +6,13 @@ metadata:
       env: staging-20min
       service: complete
       version: abcd123456
-  annotations:
+  deploymentAnnotations:
     downscaler/downscale-period: Mon-Sun 23:00-23:01 Europe/Zurich
     downscaler/upscale-period: Mon-Sun 06:00-06:01 Europe/Zurich
+  hpaAnnotations:
+    testing: hpaannotations
+  podAnnotations:
+    thisisapod: annotation
 service:
   name: complete
 ingress:

--- a/ci/values-complete.yaml
+++ b/ci/values-complete.yaml
@@ -1,0 +1,42 @@
+image_repo: public.ecr.aws/eks-distro/kubernetes/pause
+image_tag: "3.9"
+metadata:
+  labels:
+    datadog:
+      env: staging-20min
+      service: complete
+      version: abcd123456
+  annotations:
+    downscaler/downscale-period: Mon-Sun 23:00-23:01 Europe/Zurich
+    downscaler/upscale-period: Mon-Sun 06:00-06:01 Europe/Zurich
+service:
+  name: complete
+ingress:
+  hosts:
+    - www.example.com
+    - doc.example.com
+scale:
+  minReplicas: 2
+  maxReplicas: 15
+  cpuThresholdPercentage: 80
+port: 3000
+probe:
+  liveness: /api/health
+  readiness: /api/health
+resources:
+  requests:
+    cpu: 1
+    memory: 1Gi
+  limits:
+    memory: 2Gi
+env:
+  FEED_BASE_URL: https://www.feed-url.com
+
+nodeSelector:
+  provisioner-group: general
+  kubernetes.io/arch: amd64
+
+tolerations:
+  - key: karpenter.sh/default
+    operator: Exists
+    effect: NoSchedule

--- a/ci/values-minimal.yaml
+++ b/ci/values-minimal.yaml
@@ -1,0 +1,13 @@
+image_repo: public.ecr.aws/eks-distro/kubernetes/pause
+image_tag: "3.9"
+service:
+  name: minimal
+scale:
+  enabled: false
+port: 3000
+resources:
+  requests:
+    cpu: 1
+    memory: 1Gi
+  limits:
+    memory: 2Gi

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}
+  annotations:
+    {{- toYaml .Values.metadata.annotations | nindent 4 }}
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
@@ -32,7 +34,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- toYaml .Values.metadata.annotations | nindent 8 }}
+        {{- toYaml .Values.metadata.podAnnotations | nindent 8 }}
       labels:
         type: {{ .Chart.Name }}
         app: {{ .Release.Name }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}
   annotations:
-    {{- toYaml .Values.metadata.annotations | nindent 4 }}
+    {{- toYaml .Values.metadata.deploymentAnnotations | nindent 4 }}
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -2,7 +2,8 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  annotations: {{ .Values.metadata.hpaAnnotations }}
+  annotations: 
+    {{- toYaml .Values.metadata.hpaAnnotations | nindent 4 }}
   name: {{ .Release.Name }}
 spec:
   minReplicas: {{ .Values.scale.minReplicas }}

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -2,7 +2,7 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  annotations:
+  annotations: {{ .Values.metadata.hpaAnnotations }}
   name: {{ .Release.Name }}
 spec:
   minReplicas: {{ .Values.scale.minReplicas }}

--- a/values.yaml
+++ b/values.yaml
@@ -70,6 +70,7 @@ affinity: {}
 metadata:
   annotations: {}
   podAnnotations: {}
+  hpaAnnotations: {}
   labels:
     datadog:
       env: ""

--- a/values.yaml
+++ b/values.yaml
@@ -68,7 +68,7 @@ tolerations: []
 affinity: {}
 
 metadata:
-  annotations: {}
+  deploymentAnnotations: {}
   podAnnotations: {}
   hpaAnnotations: {}
   labels:

--- a/values.yaml
+++ b/values.yaml
@@ -69,6 +69,7 @@ affinity: {}
 
 metadata:
   annotations: {}
+  podAnnotations: {}
   labels:
     datadog:
       env: ""


### PR DESCRIPTION
Introducing `deploymentAnnotations` and `hpaAnnotations`.

There is a breaking change (because of a (my!) bad naming): I renamed Pod `annotations` to `podAnnotations` for consistency.
