### PR TITLE
feat: externalsecret reference

### DIFF
--- a/ci/values-complete.yaml
+++ b/ci/values-complete.yaml
@@ -46,5 +46,5 @@ tolerations:
     operator: Exists
     effect: NoSchedule
 
-secrets:
-  database: true
+externalSecrets:
+  - complete/databaseCredentials

--- a/ci/values-complete.yaml
+++ b/ci/values-complete.yaml
@@ -45,3 +45,6 @@ tolerations:
   - key: karpenter.sh/default
     operator: Exists
     effect: NoSchedule
+
+secrets:
+  database: true

--- a/ci/values-complete.yaml
+++ b/ci/values-complete.yaml
@@ -47,4 +47,5 @@ tolerations:
     effect: NoSchedule
 
 externalSecrets:
-  - complete/databaseCredentials
+  secretNames:
+    - "complete/databaseCredentials"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
           envFrom:
             {{- range .Values.externalSecrets.secretNames }}
             - secretRef:
-                name: {{ . | replace "/" "-" }}
+                name: {{ . | lower | replace "/" "-" }}
             {{- end }}
           {{- end }}
           ports:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           {{- end }}
           env:
             - name: PORT
-              value: {{ .Values.port | quote  }}
+              value: {{ .Values.port | quote }}
             {{- if .Values.metadata.labels.datadog.env }}
             - name: DD_ENV
               valueFrom:
@@ -86,34 +86,18 @@ spec:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/version']
             {{- end }}
-            {{- if .Values.secrets.database }}
-            - name: DB_ENDPOINT
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.service.name }}-database-credentials
-                  key: DB_ENDPOINT
-            - name: DB_NAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.service.name }}-database-credentials
-                  key: DB_NAME
-            - name: DB_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.service.name }}-database-credentials
-                  key: DB_USERNAME
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.service.name }}-database-credentials
-                  key: DB_PASSWORD
-            {{- end }}
-          {{- if .Values.env }}
-          {{- range $key, $val := .Values.env }}
+            {{- if .Values.env }}
+            {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
               value: {{ $val | quote }}
-          {{- end }}
-          {{- end }}
+            {{- end }}
+            {{- end }}
+          {{- if gt (len .Values.externalSecrets) 0 }}
+          envFrom:
+            {{- range .Values.externalSecrets }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.port }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -92,9 +92,9 @@ spec:
               value: {{ $val | quote }}
             {{- end }}
             {{- end }}
-          {{- if gt (len .Values.externalSecrets.secretNames) 0 }}
+          {{- with .Values.externalSecrets.secretNames }}
           envFrom:
-            {{- range .Values.externalSecrets.secretNames }}
+            {{- range . }}
             - secretRef:
                 name: {{ . | lower | replace "/" "-" }}
             {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -87,11 +87,26 @@ spec:
                   fieldPath: metadata.labels['tags.datadoghq.com/version']
             {{- end }}
             {{- if .Values.secrets.database }}
-            - name: EXTERNAL_DB_URL
+            - name: DB_ENDPOINT
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.service.name }}-database-credentials
-                  key: DB_URL
+                  key: DB_ENDPOINT
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.service.name }}-database-credentials
+                  key: DB_NAME
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.service.name }}-database-credentials
+                  key: DB_USERNAME
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.service.name }}-database-credentials
+                  key: DB_PASSWORD
             {{- end }}
           {{- if .Values.env }}
           {{- range $key, $val := .Values.env }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -86,6 +86,13 @@ spec:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/version']
             {{- end }}
+            {{- if .Values.secrets.database }}
+            - name: EXTERNAL_DB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.service.name }}-database-credentials
+                  key: DB_URL
+            {{- end }}
           {{- if .Values.env }}
           {{- range $key, $val := .Values.env }}
             - name: {{ $key }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -92,12 +92,13 @@ spec:
               value: {{ $val | quote }}
             {{- end }}
             {{- end }}
-          {{- if gt (len .Values.externalSecrets) 0 }}
+          {{- if gt (len .Values.externalSecrets.secretNames) 0 }}
           envFrom:
-            {{- range .Values.externalSecrets }}
+            {{- range .Values.externalSecrets.secretNames }}
             - secretRef:
-                name: {{ . }}
+                name: {{ . | replace "/" "-" }}
             {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.port }}

--- a/templates/external_secret.yaml
+++ b/templates/external_secret.yaml
@@ -1,6 +1,3 @@
-# Inputs:
-# - ClusterSecretStore name
-
 {{- range .Values.externalSecrets.secretNames }}
 ---
 apiVersion: external-secrets.io/v1beta1

--- a/templates/external_secret.yaml
+++ b/templates/external_secret.yaml
@@ -5,6 +5,7 @@ kind: ExternalSecret
 metadata:
   name: {{ . | lower | replace "/" "-" }}
 spec:
+  refreshInterval: {{ $.Values.externalSecrets.refreshInterval }}
   secretStoreRef:
     kind: ClusterSecretStore
     name: {{ $.Values.externalSecrets.clusterSecretStore }}

--- a/templates/external_secret.yaml
+++ b/templates/external_secret.yaml
@@ -3,13 +3,13 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ . | replace "/" "-" }}
+  name: {{ . | lower | replace "/" "-" }}
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
     name: {{ $.Values.externalSecrets.clusterSecretStore }}
   target:
-    name: {{ . | replace "/" "-" }}
+    name: {{ . | lower | replace "/" "-" }}
     creationPolicy: Owner
   dataFrom:
   - extract:

--- a/templates/external_secret.yaml
+++ b/templates/external_secret.yaml
@@ -1,0 +1,20 @@
+# Inputs:
+# - ClusterSecretStore name
+
+{{- range .Values.externalSecrets.secretNames }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ . | replace "/" "-" }}
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: {{ $.Values.externalSecrets.clusterSecretStore }}
+  target:
+    name: {{ . | replace "/" "-" }}
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      key: {{ . }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -96,3 +96,6 @@ topologySpreadConstraints:
 update:
   maxUnavailable: 0%
   maxSurge: 25%
+
+secrets:
+  database: false

--- a/values.yaml
+++ b/values.yaml
@@ -97,7 +97,7 @@ update:
   maxUnavailable: 0%
   maxSurge: 25%
 
-# list of secret names that should be fetched from SecretsManager and made available to the Pods
 externalSecrets:
   clusterSecretStore: aws-secretsmanager
+  # secret names that should be fetched and made available to the Pods
   secretNames: []

--- a/values.yaml
+++ b/values.yaml
@@ -97,5 +97,5 @@ update:
   maxUnavailable: 0%
   maxSurge: 25%
 
-secrets:
-  database: false
+# list of secret names that should be fetched from SecretsManager and made available to the Pods
+externalSecrets: []

--- a/values.yaml
+++ b/values.yaml
@@ -98,4 +98,6 @@ update:
   maxSurge: 25%
 
 # list of secret names that should be fetched from SecretsManager and made available to the Pods
-externalSecrets: []
+externalSecrets:
+  clusterSecretStore: aws-secretsmanager
+  secretNames: []

--- a/values.yaml
+++ b/values.yaml
@@ -98,6 +98,7 @@ update:
   maxSurge: 25%
 
 externalSecrets:
+  refreshInterval: 5m
   clusterSecretStore: aws-secretsmanager
   # secret names that should be fetched and made available to the Pods
   secretNames: []


### PR DESCRIPTION
**Note**: Requires `external-secrets` operator to be installed in the cluster. ([example](https://github.com/tx-pts-dai/atm-platform-poc/blob/399711bbe88dad2babc5d72f2e4ff2a6754b2bcf/secretsmanager.tf))

### Problem
Defining a standard way to pass secrets to the application.

### Proposal
Introduce an `externalSecrets` (list) variable that instruments which secrets should be pulled from SecretsManager and loaded as environment variables into the Pod.

Devs could therefore be in complete control of the secrets or the Infrastructure could create them automatically (e.g. when creating a db).
This is a more secure way to pass configuration and secrets to your applications. No need to directly deploy them.
